### PR TITLE
Adding support for intel Iris xe and Intel Arc graphics

### DIFF
--- a/src/VR/org/vivecraft/provider/VRRenderer.java
+++ b/src/VR/org/vivecraft/provider/VRRenderer.java
@@ -443,7 +443,12 @@ public abstract class VRRenderer
             this.checkGLError("Start Init");
             int i = minecraft.getWindow().getScreenWidth() < 1 ? 1 : minecraft.getWindow().getScreenWidth();
             int j = minecraft.getWindow().getScreenHeight() < 1 ? 1 : minecraft.getWindow().getScreenHeight();
-
+	
+	if (Config.openGlRenderer.toLowerCase().contains("Intel® UHD"))
+            {
+                throw new RenderConfigException("Incompatible", LangHelper.get("vivecraft.messages.intelgraphics", Config.openGlRenderer));
+            }
+		
             if (!this.isInitialized())
             {
                 throw new RenderConfigException(RENDER_SETUP_FAILURE_MESSAGE + this.getName(), LangHelper.get(this.getinitError()));

--- a/src/VR/org/vivecraft/provider/VRRenderer.java
+++ b/src/VR/org/vivecraft/provider/VRRenderer.java
@@ -444,11 +444,6 @@ public abstract class VRRenderer
             int i = minecraft.getWindow().getScreenWidth() < 1 ? 1 : minecraft.getWindow().getScreenWidth();
             int j = minecraft.getWindow().getScreenHeight() < 1 ? 1 : minecraft.getWindow().getScreenHeight();
 
-            if (Config.openGlRenderer.toLowerCase().contains("intel"))
-            {
-                throw new RenderConfigException("Incompatible", LangHelper.get("vivecraft.messages.intelgraphics", Config.openGlRenderer));
-            }
-
             if (!this.isInitialized())
             {
                 throw new RenderConfigException(RENDER_SETUP_FAILURE_MESSAGE + this.getName(), LangHelper.get(this.getinitError()));


### PR DESCRIPTION
In addition to stop blocking all of intel graphics, Just block Intel Uhd graphics as those don't seem to be compatible even with normal vr. Intel iris xe and Intel Arc gpus recently got new driver updates which is allowing more opengl games to run including minecraft bedrock in vr at a high performance. 

